### PR TITLE
Fix gilded armor effect 1.19 (possibly other versions)

### DIFF
--- a/src/main/java/net/adventurez/item/armor/StoneGolemArmor.java
+++ b/src/main/java/net/adventurez/item/armor/StoneGolemArmor.java
@@ -78,12 +78,12 @@ public class StoneGolemArmor extends ArmorItem {
         if (stack.getItem() == ItemInit.STONE_GOLEM_CHESTPLATE) {
             NbtCompound tag = stack.getNbt();
             if (tag != null && tag.contains("armor_time")) {
-                if (tag.getBoolean("activating_armor") && tag.getInt("armor_time") + (ConfigInit.CONFIG.stone_golem_armor_effect_duration * 2) < (int) world.getTime()) {
-                    tag.putBoolean("activating_armor", false);
-                }
                 if (tag.getBoolean("activating_armor") && tag.getInt("armor_time") + ConfigInit.CONFIG.stone_golem_armor_effect_duration < (int) world.getTime()) {
                     entity.setFireTicks(0);
                     tag.putBoolean("activating_armor_visuals", false);
+                }
+                if (tag.getBoolean("activating_armor") && tag.getInt("armor_time") + (ConfigInit.CONFIG.stone_golem_armor_effect_duration * 2) < (int) world.getTime()) {
+                    tag.putBoolean("activating_armor", false);
                 }
             }
         }


### PR DESCRIPTION
If the player disconnected before the effect was recharged, on reconnect the armor chestplate item's NBT would be stuck in a state where the effect could not activate again because "activating_armor" tag was set to false and then "activating_armor_visuals" could not get deactivated anymore blocking the effect logic. By inverting the conditions order, when the player reconnects both conditions are executed in the first pass first by deactivating the "activating_armor_visuals" THEN "activating_armor" fully recharging the effect and preserving correct armor chestplate NBT state on player reconnect.

How to replicate the initial bug:

- Create a server which runs even when you are disconnected (world time progressing)
- Activate the armor by going into lava, you are protected against fire all is good
- Disconnect and wait more than 2 minutes
- Reconnect and observe corrupted armor chestplate NBT with `activating_armor` false and `activating_armor_visuals` true and inability to benefit from the armor's effect

After this fix, the bug scenario is no longer reproducible and the armor remains usable and the effect is fully recharged even when the player comes back after being offline (and inventoryTick not called during that time because the player was offline).

With this change, all armors which are already corrupted will remain corrupted, but new armors will not get corrupted. For me it's an acceptable solution, but you may want to add code that checks if `activating_armor` is false then set `activating_armor_visuals` to false as well to fix the armor's NBT.